### PR TITLE
Fix Review Clusters regex pattern bug

### DIFF
--- a/src/services/dataAnalysis/enhancedDataAnalysisService.ts
+++ b/src/services/dataAnalysis/enhancedDataAnalysisService.ts
@@ -207,7 +207,7 @@ class EnhancedDataAnalysisService {
           if (review.text) {
             const words = review.text
               .toLowerCase()
-              .split(/\\s+/)
+              .split(/\s+/)
               .filter((word: string) => word.length > 4 && !clusters[theme].keywords.includes(word));
             
             // Add up to 3 keywords per review


### PR DESCRIPTION
## Fix Review Clusters Feature

This PR fixes the Review Clusters tab that was returning "No review clusters detected".

### Issue
The regex pattern for splitting words in the `clusterReviews` method had incorrect syntax with double backslashes:
```typescript
.split(/\\s+/)  // Incorrect - double backslash
```

### Fix
Updated to use the correct regex pattern:
```typescript
.split(/\s+/)  // Correct - single backslash
```

### Impact
- The Review Clusters feature will now properly extract keywords from review text
- Clusters will be correctly identified and displayed with their associated keywords
- The "No review clusters detected" message will only appear when there are truly no themes to cluster

### Testing
After this fix is applied:
1. The Review Clusters tab should display theme distribution in a pie chart
2. Cluster details should show theme names, sentiment badges, and associated keywords
3. The feature should work correctly for all three businesses